### PR TITLE
Make curl write newline

### DIFF
--- a/authorize.sh
+++ b/authorize.sh
@@ -26,8 +26,7 @@ fi
 
 USER_NAME="$1"
 
-curl "https://github.com/${USER_NAME}.keys" | sed -e '$a\' | while read key
+curl -w "\n" "https://github.com/${USER_NAME}.keys" | while read key
 do
-	echo "hallo"
 	echo "environment=\"GITHUB_USERNAME=$USER_NAME\" $key" | tee -a "$GIT_HOME/.ssh/authorized_keys"
 done

--- a/authorize.sh
+++ b/authorize.sh
@@ -28,5 +28,5 @@ USER_NAME="$1"
 
 curl -w "\n" "https://github.com/${USER_NAME}.keys" | while read key
 do
-	echo "environment=\"GITHUB_USERNAME=$USER_NAME\" $key" | tee -a "$GIT_HOME/.ssh/authorized_keys"
+	[ "" != "key" ] && echo "environment=\"GITHUB_USERNAME=$USER_NAME\" $key" | tee -a "$GIT_HOME/.ssh/authorized_keys"
 done


### PR DESCRIPTION
This is a variation of e0c04f025c

What did the `sed` command actually do?

`curl` will now always append a newline. In case `sed` was more sophisticated about when to append the newline, this could break something.
